### PR TITLE
Ensure dtype consistencies thus fixing FutureWarning

### DIFF
--- a/minder_downloader/utils.py
+++ b/minder_downloader/utils.py
@@ -141,7 +141,7 @@ def mine_transition(df,value:str,datetime:str='start_date',window:int=1):
        end_date = df[datetime].shift(-window).rename('end_date')
        source = df[value].rename('source')
        sink = df[value].shift(-window).rename('sink')
-       transition = pd.Series(rolling_window(df[value].values,window+1)).rename('transition')
+       transition = pd.Series(rolling_window(df[value].values,window+1), dtype=object).rename('transition')
        return pd.concat([start_date, end_date, source,sink,transition.reindex(sink.index), dur], axis=1)
     else:
        return pd.DataFrame() 


### PR DESCRIPTION
This PR will fix the FutureWarning generated due to line 144. The error is generated because in the future version of Pandas, the default dtype for empty series will be object instead of float64, which is the current behaviour of the code. This PR will ensure that the dtype is consistent across all usage.