### PR TITLE
Ensure MINDER_DOWNLOADER_HOME is set

### DIFF
--- a/minder_downloader/config.py
+++ b/minder_downloader/config.py
@@ -28,14 +28,11 @@ def check_config():
 
 
 def check_root_folder():
-    root = os.environ.get('MINDER_DOWNLOADER_HOME')
-    if root is None:
-        root = Path.home()
-    minder_home = Path(f'{root}{os.sep}.minder')
-    if not minder_home.exists():
-        minder_home.mkdir(parents=True)
-        os.environ['MINDER_DOWNLOADER_HOME'] = f'{minder_home}'
-    return f'{minder_home}'
+    root = Path(os.environ.get('MINDER_DOWNLOADER_HOME', str(Path.home() / '.minder')))
+    if not root.exists():
+        root.mkdir(parents=True)
+    os.environ['MINDER_DOWNLOADER_HOME'] = str(root)
+    return os.environ['MINDER_DOWNLOADER_HOME']
 
 
 def check_token_file(root):


### PR DESCRIPTION
This fixes a minor bug where MINDER_DOWNLOADER_HOME wasn't set if config folder didn't already exist